### PR TITLE
refactor: renomeia services do docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Microsserviço de Catálogo de Produtos e Categorias do Sistema de Gestão de Re
 4. Faça uma cópia do arquivo `.env.template` com o nome `.env` e preencha as variáveis de ambiente dentro dele;
 5. Execute o comando `npm install` para instalar os pacotes npm;
 6. Use o comando `npm run start` para iniciar a aplicação.
-7. Execute o comando `docker-compose up -d db` para iniciar o container do banco de dados;
+7. Execute o comando `docker-compose up -d db-catalogo` para iniciar o container do banco de dados;
 8. Acesse o Swagger em http://localhost:3000/swagger/
 
 <details>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,9 @@
 version: '3.9'
 
 services:
-  db:
-    container_name: db
-    hostname: db
+  db-catalogo:
+    container_name: db-catalogo
+    hostname: db-catalogo
     image: postgres:16.1
     ports:
       - '5432:5432'
@@ -28,9 +28,9 @@ services:
     networks:
       - default
 
-  api:
-    container_name: api
-    hostname: api
+  api-catalogo:
+    container_name: api-catalogo
+    hostname: api-catalogo
     build:
       context: .
       dockerfile: Dockerfile
@@ -41,25 +41,17 @@ services:
     env_file:
       - .env
     environment:
-      DB_HOST: db
+      DB_HOST: db-catalogo
       DB_PORT: 5432
       DB_USER: ${DB_USERNAME:-pguser}
       DB_PASSWORD: ${DB_PASSWORD:-pgpwd}
       DB_NAME: ${DB_NAME:-rms}
       DB_SSL: ${DB_SSL:-false}
-      COGNITO_USER_POOL_ID: ${COGNITO_USER_POOL_ID:-}
-      COGNITO_CLIENT_ID: ${COGNITO_CLIENT_ID:-}
-      ENABLE_MERCADOPAGO: ${ENABLE_MERCADOPAGO:-false}
-      ACCESS_TOKEN_MERCADOPAGO: ${ACCESS_TOKEN_MERCADOPAGO:-}
-      USER_ID_MERCADOPAGO: ${USER_ID_MERCADOPAGO:-}
-      EXTERNAL_POS_ID_MERCADOPAGO: ${EXTERNAL_POS_ID_MERCADOPAGO:-}
-      WEBHOOK_URL_MERCADOPAGO: ${WEBHOOK_URL_MERCADOPAGO:-}
-      IDEMPOTENCY_KEY_MERCADOPAGO: ${IDEMPOTENCY_KEY_MERCADOPAGO:-a005986e-f97c-4274-91cf-b32d2672824f}
     restart: always
     networks:
       - default
     depends_on:
-      - db
+      - db-catalogo
 
 networks:
   default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   db-catalogo:
     container_name: db-catalogo
     hostname: db-catalogo
-    image: postgres:16.1
+    image: postgres:15.6
     ports:
       - '5432:5432'
     expose:


### PR DESCRIPTION
Renomeando os Services dentro do `docker-compose.yaml` para que seja possível rodar mais de um microsserviço ao mesmo tempo na máquina local, sem conflitar o nome dos containers.