### PR TITLE
fix: Atualiza objectName no SecretProvider

### DIFF
--- a/k8s/production/bff/secret-provider.yaml
+++ b/k8s/production/bff/secret-provider.yaml
@@ -21,7 +21,7 @@ spec:
     # Informe abaixo no campo objectName os nomes dos Segredos do AWS Secrets Manager que deseja acessar.
     # Certifique-se de que as Keys declaradas abaixo existem e estão preenchidas na AWS, caso contrário receberá o erro "Failed to fetch secret from all regions"
     objects: |
-      - objectName: "prod/RMS/Postgresql"
+      - objectName: "prod/catalogo/Postgresql"
         objectType: "secretsmanager"
         jmesPath:
           - path: "host"


### PR DESCRIPTION
Atualizando o `objectName` no SecretProviderClass do K8s para o novo nome que coloquei no Terraform. Caso não for ajustado, não irá encontrar os secrets quando subir a aplicação na AWS.

Card #114 do Trello
https://trello.com/c/clOmGwup/114-renomear-o-objectname-do-secret-que-cont%C3%A9m-o-usu%C3%A1rio-e-senha-do-banco-de-dados-nos-manifestos-do-k8s-nos-novos-microsservi%C3%A7os