### PR TITLE
refactor: altera numero da porta do nestjs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ RUN npm install --ignore-scripts
 RUN npm run build
 
 
-EXPOSE 3000
+EXPOSE 3001
 USER nonroot
 CMD [ "node", "dist/main.js" ]

--- a/api.http
+++ b/api.http
@@ -1,16 +1,16 @@
 ### Healthcheck
-GET http://localhost:3000/
+GET http://localhost:3001/
 
 ##################################################
 
 ### Listar categorias
-GET http://localhost:3000/categoria
+GET http://localhost:3001/categoria
 
 ### Detalhes de uma categoria
-GET http://localhost:3000/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
+GET http://localhost:3001/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
 
 ### Criar categoria
-POST http://localhost:3000/categoria
+POST http://localhost:3001/categoria
 Content-Type: application/json
 
 {
@@ -19,7 +19,7 @@ Content-Type: application/json
 }
 
 ### Editar categoria
-PUT http://localhost:3000/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
+PUT http://localhost:3001/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
 Content-Type: application/json
 
 {
@@ -27,21 +27,21 @@ Content-Type: application/json
 }
 
 ### Remover categoria
-DELETE http://localhost:3000/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
+DELETE http://localhost:3001/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
 
 ##################################################
 
 ### Listar produtos
-GET http://localhost:3000/produto
+GET http://localhost:3001/produto
 
 ### Listar produtos por categoria
-GET http://localhost:3000/produto/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
+GET http://localhost:3001/produto/categoria/9fbc614b-9b44-4d35-8ec7-36e55ba7f0f4
 
 ### Detalhes de um produto
-GET http://localhost:3000/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3
+GET http://localhost:3001/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3
 
 ### Criar produto
-POST http://localhost:3000/produto
+POST http://localhost:3001/produto
 Content-Type: application/json
 
 {
@@ -53,7 +53,7 @@ Content-Type: application/json
 }
 
 ### Editar produto
-PUT http://localhost:3000/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3
+PUT http://localhost:3001/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3
 Content-Type: application/json
 
 {
@@ -65,4 +65,4 @@ Content-Type: application/json
 }
 
 ### Remover produto
-DELETE http://localhost:3000/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3
+DELETE http://localhost:3001/produto/6a1f1007-b48a-458b-8009-9f2701eae8f3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     hostname: db-catalogo
     image: postgres:15.6
     ports:
-      - '5432:5432'
+      - '8001:5432'
     expose:
       - 5432
     healthcheck:
@@ -35,9 +35,9 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - '3000:3000'
+      - '3001:3001'
     expose:
-      - 3000
+      - 3001
     env_file:
       - .env
     environment:

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,6 +13,6 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('swagger', app, document);
   app.useGlobalPipes(new ValidationPipe({ transform: true, whitelist: true }));
-  await app.listen(3000);
+  await app.listen(3001);
 }
 bootstrap();


### PR DESCRIPTION
Alterando o número da porta do NestJs para evitar conflitos ao executar múltiplos microsserviços ao mesmo tempo na máquina local.

- API de Catálogo vai ficar na porta `3001`
- API de Pedidos vai ficar na porta `3002`
- API de Pagamentos vai ficar na porta `3003`
- PostgreSQL da API de Catálogo vai ficar na porta `8001`
- PostgreSQL da API de Pedidos vai ficar na porta `8002`