### PR TITLE
fix: define um nome para a rede do docker compose

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 DB_HOST=localhost
-DB_PORT=5432
+DB_PORT=8001
 DB_USERNAME=pguser
 DB_PASSWORD="pgpwd"
 DB_NAME=catalogo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - postgres:/data/postgres
     restart: always
     networks:
-      - default
+      - rms
 
   api-catalogo:
     container_name: api-catalogo
@@ -49,12 +49,13 @@ services:
       DB_SSL: ${DB_SSL:-false}
     restart: always
     networks:
-      - default
+      - rms
     depends_on:
       - db-catalogo
 
 networks:
-  default:
+  rms:
+    name: rms_network
     driver: bridge
 
 volumes:


### PR DESCRIPTION
Definindo um nome para a rede do docker compose para que um microsserviço em uma stack do docker compose possa chamar microsserviços em outras stacks do docker compose.